### PR TITLE
Add Pipeline Annotations and Evaluation function

### DIFF
--- a/mlblocks_pipelines/graph.graph_matching.default.json
+++ b/mlblocks_pipelines/graph.graph_matching.default.json
@@ -1,0 +1,29 @@
+{
+    "metadata": {
+        "name": "graph/graph_matching/default",
+        "data_type": "graph",
+        "task_type": "graph_matching"
+    },
+    "validation": {
+        "dataset": "dic28",
+        "context": {
+            "graph": "$graph",
+            "graphs": "$graphs",
+            "node_columns": ["graph1", "graph2"]
+        }
+    },
+    "primitives": [
+        "networkx.link_prediction_feature_extraction",
+        "networkx.graph_feature_extraction",
+        "mlprimitives.feature_extraction.CategoricalEncoder",
+        "sklearn.preprocessing.Imputer",
+        "xgboost.XGBClassifier"
+    ],
+    "hyperparameters": {
+        "xgboost.XGBClassifier#1": {
+            "n_jobs": -1,
+            "learning_rate": 0.1,
+            "n_estimators": 300
+        }
+    }
+}

--- a/mlblocks_pipelines/graph.link_prediction.default.json
+++ b/mlblocks_pipelines/graph.link_prediction.default.json
@@ -1,0 +1,30 @@
+{
+    "metadata": {
+        "name": "graph/link_prediction/default",
+        "data_type": "graph",
+        "task_type": "link_prediction"
+    },
+    "validation": {
+        "dataset": "umls",
+        "context": {
+            "graph": "$graph",
+            "node_columns": ["source", "target"]
+        }
+    },
+    "primitives": [
+        "networkx.link_prediction_feature_extraction",
+        "mlprimitives.feature_extraction.CategoricalEncoder",
+        "sklearn.preprocessing.StandardScaler",
+        "xgboost.XGBClassifier"
+    ],
+    "hyperparameters": {
+        "xgboost.XGBClassifier#1": {
+            "n_jobs": -1,
+            "learning_rate": 0.1,
+            "n_estimators": 300,
+            "max_depth": 3,
+            "gamma": 0,
+            "min_child_weight": 1
+        }
+    }
+}

--- a/mlblocks_primitives/xgboost.XGBClassifier.json
+++ b/mlblocks_primitives/xgboost.XGBClassifier.json
@@ -49,10 +49,10 @@
         "tunable": {
             "n_estimators": {
                 "type": "int",
-                "default": 10,
+                "default": 100,
                 "range": [
                     10,
-                    500
+                    1000
                 ]
             },
             "max_depth": {
@@ -65,7 +65,7 @@
             },
             "learning_rate": {
                 "type": "float",
-                "default": 0,
+                "default": 0.1,
                 "range": [
                     0,
                     1

--- a/mlblocks_primitives/xgboost.XGBRegressor.json
+++ b/mlblocks_primitives/xgboost.XGBRegressor.json
@@ -49,10 +49,10 @@
         "tunable": {
             "n_estimators": {
                 "type": "int",
-                "default": 10,
+                "default": 100,
                 "range": [
                     10,
-                    500
+                    1000
                 ]
             },
             "max_depth": {
@@ -65,7 +65,7 @@
             },
             "learning_rate": {
                 "type": "float",
-                "default": 0,
+                "default": 0.1,
                 "range": [
                     0,
                     1

--- a/mlprimitives/__init__.py
+++ b/mlprimitives/__init__.py
@@ -5,3 +5,94 @@
 __author__ = 'MIT Data To AI Lab'
 __email__ = 'dailabmit@gmail.com'
 __version__ = '0.1.2-dev'
+
+import argparse
+import logging
+import os
+import warnings
+
+from mlblocks import add_primitives_path, get_primitives_paths
+
+from mlprimitives.evaluation import score_pipeline
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _logging_setup(verbosity=1):
+    log_level = (3 - verbosity) * 10
+    fmt = '%(asctime)s - %(levelname)s - %(message)s'
+    formatter = logging.Formatter(fmt)
+    LOGGER.setLevel(log_level)
+    LOGGER.propagate = False
+
+    console_handler = logging.StreamHandler()
+    console_handler.setLevel(log_level)
+    console_handler.setFormatter(formatter)
+    LOGGER.addHandler(console_handler)
+
+
+def _test(args):
+    print('Scoring pipeline: {}'.format(args.pipeline))
+    score, stdev = score_pipeline(args.pipeline, args.splits)
+    print('Obtained Score: {:.4f} +/- {:.4f}'.format(score, stdev))
+
+
+def _get_primitives(pattern):
+    primitives = list()
+    for base_path in get_primitives_paths():
+        if os.path.exists(base_path):
+            for filename in os.listdir(base_path):
+                if pattern in filename and filename.endswith('.json'):
+                    primitives.append(filename[:-5])
+
+    return list(sorted(primitives))
+
+
+def _list(args):
+    print('\n'.join(_get_primitives(args.pattern)))
+
+
+def _parse_args():
+    parser = argparse.ArgumentParser(description='MLPrimitives Command Line Interface')
+
+    parser.add_argument(
+        '-p', '--primitives-path', action='append', help=(
+            'Path where primitives should be looked for. Use multiple '
+            'times in order to add multiple directories'
+        )
+    )
+    parser.add_argument('-v', '--verbose', action='count', default=0)
+
+    subparsers = parser.add_subparsers(title='action', help='Action to perform')
+
+    subparser = subparsers.add_parser('test', help='Test a single pipeline.')
+    subparser.set_defaults(action=_test)
+    subparser.add_argument('pipeline')
+    subparser.add_argument('-s', '--splits', default=5, type=int,
+                           help='Number of splits to use for Cross Validation')
+
+    subparser = subparsers.add_parser('list', help='List available primitives')
+    subparser.set_defaults(action=_list)
+    subparser.add_argument('pattern', nargs='?', default='')
+
+    return parser.parse_args()
+
+
+def _add_primitives_paths(paths):
+    if paths:
+        for path in paths:
+            add_primitives_path(path)
+
+
+def _process_common_args(args):
+    _add_primitives_paths(args.primitives_path)
+    _logging_setup(args.verbose)
+
+
+def _main():
+    warnings.filterwarnings('ignore', category=DeprecationWarning)
+
+    args = _parse_args()
+    _process_common_args(args)
+
+    args.action(args)

--- a/mlprimitives/adapters/networkx.py
+++ b/mlprimitives/adapters/networkx.py
@@ -13,6 +13,8 @@ LOGGER = logging.getLogger(__name__)
 def graph_pairs_feature_extraction(X, functions, node_columns, graph=None):
     functions = [import_object(function) for function in functions]
 
+    X = X.copy()
+
     pairs = X[node_columns].values
 
     # for i, graph in enumerate(graphs):

--- a/mlprimitives/evaluation.py
+++ b/mlprimitives/evaluation.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+
+"""
+MLPrimitives Evaluation functions.
+
+Collection of functions and tools to evaluate the performance
+of a pipeline over a given dataset.
+"""
+
+import json
+from copy import copy
+
+import numpy as np
+from mlblocks import MLPipeline, datasets
+
+
+def build_pipeline(pipeline_spec):
+    pipeline = MLPipeline(
+        pipeline_spec['primitives'],
+        pipeline_spec.get('init_params', dict()),
+        pipeline_spec.get('input_names', dict()),
+        pipeline_spec.get('output_names', dict()),
+    )
+
+    hyperparameters = pipeline_spec.get('hyperparameters')
+    if hyperparameters:
+        pipeline.set_hyperparameters(hyperparameters)
+
+    return pipeline
+
+
+def load_dataset(name):
+    loader_name = 'load_' + name
+    loader = getattr(datasets, loader_name)
+    return loader()
+
+
+def get_value(dataset, value):
+    if isinstance(value, str) and value.startswith('$'):
+        value = getattr(dataset, value[1:])
+    elif isinstance(value, dict):
+        value = get_context(dataset, value)
+    elif isinstance(value, list):
+        value = [get_value(dataset, v) for v in value]
+
+    return copy(value)
+
+
+def get_context(dataset, context_spec):
+    context = dict()
+    for key, value in context_spec.items():
+        context[key] = get_value(dataset, value)
+
+    return context
+
+
+def score_pipeline(pipeline_metadata, n_splits=5):
+    if isinstance(pipeline_metadata, str):
+        with open(pipeline_metadata, 'r') as pipeline_file:
+            pipeline_metadata = json.load(pipeline_file)
+
+    validation = pipeline_metadata['validation']
+    dataset = load_dataset(validation['dataset'])
+
+    scores = list()
+    for X_train, X_test, y_train, y_test in dataset.get_splits(n_splits):
+        context = get_context(dataset, validation.get('context', dict()))
+        pipeline = build_pipeline(pipeline_metadata)
+        pipeline.fit(X_train, y_train, **context)
+        predictions = pipeline.predict(X_test, **context)
+
+        scores.append(dataset.score(y_test, predictions))
+
+    return np.mean(scores), np.std(scores)

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,13 +3,13 @@ current_version = 0.1.2-dev
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?
-serialize = 
+serialize =
 	{major}.{minor}.{patch}-{release}
 	{major}.{minor}.{patch}
 
 [bumpversion:part:release]
 optional_value = release
-values = 
+values =
 	dev
 	release
 

--- a/setup.py
+++ b/setup.py
@@ -20,11 +20,12 @@ install_requires = [
     'featuretools>=0.1.17',
     'lightfm>=1.15',
     'networkx>=2.0',
-    'numpy>=1.14.0',
+    'numpy>=1.15.2',
+    'pandas>=0.23.4',
     'opencv-python>=3.4.0.12',
     'python-louvain>=0.10',
     'scikit-image>=0.13.1',
-    'scikit-learn>=0.19.1',
+    'scikit-learn>=0.20.0',
     'scipy>=1.1.0',
     'tensorflow==1.8.0',
     'xgboost>=0.72.1',
@@ -93,6 +94,11 @@ setup(
     ],
     data_files = list(data_files.items()),
     description="MLBlocks Primitives",
+    entry_points = {
+        'console_scripts': [
+            'mlprimitives=mlprimitives:_main'
+        ],
+    },
     extras_require=extras_require,
     install_requires=install_requires,
     license="MIT license",


### PR DESCRIPTION
Resolve #12 

Add a `score_pipeline` function to load an MLBlocks pipeline JSON and evaluate the pipeline score over the specified dataset using cross validation.

Also add the `mlprimitives` command line interface with two simple functionalities:
* Score a pipeline with the command: `mlprimitives test path/to/the/pipeline.json`
* List available primitives, optionally filtering by a pattern, using the command: `mlprimitives list [pattern]`