### PR TITLE
Add ClassEncoder and ClassDecoder Primitives

### DIFF
--- a/mlblocks_pipelines/tabular.classification.default.json
+++ b/mlblocks_pipelines/tabular.classification.default.json
@@ -1,0 +1,28 @@
+{
+    "metadata": {
+        "name": "tabular/classification/default",
+        "data_type": "tabular",
+        "task_type": "classification"
+    },
+    "validation": {
+        "dataset": "iris",
+        "context": {}
+    },
+    "primitives": [
+        "mlprimitives.preprocessing.ClassEncoder",
+        "sklearn.preprocessing.Imputer",
+        "sklearn.preprocessing.StandardScaler",
+        "xgboost.XGBClassifier",
+        "mlprimitives.preprocessing.ClassDecoder"
+    ],
+    "hyperparameters": {
+        "xgboost.XGBClassifier#1": {
+            "n_jobs": -1,
+            "learning_rate": 0.1,
+            "n_estimators": 300,
+            "max_depth": 3,
+            "gamma": 0,
+            "min_child_weight": 1
+        }
+    }
+}

--- a/mlblocks_primitives/mlprimitives.preprocessing.ClassDecoder.json
+++ b/mlblocks_primitives/mlprimitives.preprocessing.ClassDecoder.json
@@ -1,0 +1,39 @@
+{
+    "name": "mlprimitives.preprocessing.ClassDecoder",
+    "author": "Carles Sala <carles@pythiac.com>",
+    "description": "Decode an array of strings using integers.",
+    "classifiers": {
+        "type": "preprocessor",
+        "subtype": "data_cleanup"
+    },
+    "modalities": [],
+    "primitive": "mlprimitives.preprocessing.ClassDecoder",
+    "fit": {
+        "method": "fit",
+        "args": [
+            {
+                "name": "classes",
+                "type": "ndarray"
+            }
+        ]
+    },
+    "produce": {
+        "method": "decode",
+        "args": [
+            {
+                "name": "y",
+                "type": "ndarray"
+            }
+        ],
+        "output": [
+            {
+                "name": "y",
+                "type": "ndarray"
+            }
+        ]
+    },
+    "hyperparameters": {
+        "fixed": {},
+        "tunable": {}
+    }
+}

--- a/mlblocks_primitives/mlprimitives.preprocessing.ClassEncoder.json
+++ b/mlblocks_primitives/mlprimitives.preprocessing.ClassEncoder.json
@@ -1,0 +1,44 @@
+{
+    "name": "mlprimitives.preprocessing.ClassEncoder",
+    "author": "Carles Sala <carles@pythiac.com>",
+    "description": "Encode an array of strings using integers.",
+    "classifiers": {
+        "type": "preprocessor",
+        "subtype": "data_cleanup"
+    },
+    "modalities": [],
+    "primitive": "mlprimitives.preprocessing.ClassEncoder",
+    "fit": {
+        "method": "fit",
+        "args": [
+            {
+                "name": "y",
+                "type": "ndarray"
+            }
+        ]
+    },
+    "produce": {
+        "method": "encode",
+        "args": [
+            {
+                "name": "y",
+                "default": null,
+                "type": "ndarray"
+            }
+        ],
+        "output": [
+            {
+                "name": "y",
+                "type": "ndarray"
+            },
+            {
+                "name": "classes",
+                "type": "ndarray"
+            }
+        ]
+    },
+    "hyperparameters": {
+        "fixed": {},
+        "tunable": {}
+    }
+}

--- a/mlprimitives/preprocessing.py
+++ b/mlprimitives/preprocessing.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+
+from sklearn.preprocessing import LabelEncoder
+
+
+class ClassEncoder():
+
+    def __init__(self):
+        self._label_encoder = LabelEncoder()
+
+    def fit(self, y):
+        self._label_encoder.fit(y)
+
+    def encode(self, y):
+        if y is not None:
+            classes = self._label_encoder.classes_
+            y = self._label_encoder.transform(y)
+            return y, classes
+
+
+class ClassDecoder():
+
+    def __init__(self):
+        self._label_encoder = LabelEncoder()
+
+    def fit(self, classes):
+        self._label_encoder.classes_ = classes
+
+    def decode(self, y):
+        return self._label_encoder.inverse_transform(y)


### PR DESCRIPTION
Resolve #24 

Add ClassEncoder and ClassDecoder primitives to allow encoding the output classes in a classification problem where the classes are not numerical, as well as a pipeline that uses them.