### PR TITLE
Fix index usage in featuretools.dfs

### DIFF
--- a/mlblocks_pipelines/multi_table.classification.default.json
+++ b/mlblocks_pipelines/multi_table.classification.default.json
@@ -1,0 +1,34 @@
+{
+    "metadata": {
+        "name": "multi_table/classification/default",
+        "data_type": "multi_table",
+        "task_type": "classification"
+    },
+    "validation": {
+        "dataset": "wikiqa",
+        "context": {
+            "entities": "$entities",
+            "relationships": "$relationships",
+            "target_entity": "data"
+        }
+    },
+    "primitives": [
+        "mlprimitives.preprocessing.ClassEncoder",
+        "featuretools.dfs",
+        "xgboost.XGBClassifier",
+        "mlprimitives.preprocessing.ClassDecoder"
+    ],
+    "hyperparameters": {
+        "featuretools.dfs#1": {
+            "encode": true
+        },
+        "xgboost.XGBClassifier#1": {
+            "n_jobs": -1,
+            "learning_rate": 0.1,
+            "n_estimators": 300,
+            "max_depth": 3,
+            "gamma": 0,
+            "min_child_weight": 1
+        }
+    }
+}

--- a/mlblocks_pipelines/single_table.classification.default.json
+++ b/mlblocks_pipelines/single_table.classification.default.json
@@ -1,7 +1,7 @@
 {
     "metadata": {
-        "name": "tabular/classification/default",
-        "data_type": "tabular",
+        "name": "single_table/classification/default",
+        "data_type": "single_table",
         "task_type": "classification"
     },
     "validation": {

--- a/mlblocks_primitives/featuretools.dfs.json
+++ b/mlblocks_primitives/featuretools.dfs.json
@@ -75,6 +75,12 @@
         ]
     },
     "hyperparameters": {
+        "fixed": {
+            "copy": {
+                "type": "bool",
+                "default": false
+            }
+        },
         "tunable": {
             "max_depth": {
                 "type": "int",

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ install_requires = [
 
 
 tests_require = [
-    'mlblocks>=0.2.0',
+    'mlblocks>=0.2.4',
     'pytest>=3.4.2',
     'google-compute-engine==2.8.12',    # required by travis
 ]


### PR DESCRIPTION
Resolve #46 

Change the way the index is taken from X in featuretools.dfs primitive.

Now the column is used instead of the index, so there is no need to have a column identical to the dataframe index.