### PR TITLE
Fix stopwrods typo

### DIFF
--- a/mlblocks_primitives/mlprimitives.text.TextCleaner.json
+++ b/mlblocks_primitives/mlprimitives.text.TextCleaner.json
@@ -52,7 +52,7 @@
                 "type": "bool",
                 "default": true
             },
-            "stopwrods": {
+            "stopwords": {
                 "type": "bool",
                 "default": true
             },

--- a/mlprimitives/text.py
+++ b/mlprimitives/text.py
@@ -24,7 +24,7 @@ class TextCleaner(object):
     STOPWORDS = dict()
 
     def __init__(self, column=None, language='multi', lower=True, accents=True,
-                 stopwrods=True, non_alpha=True, single_chars=True):
+                 stopwords=True, non_alpha=True, single_chars=True):
         self.column = column
         self.language = language
         self.language_code = None


### PR DESCRIPTION
Resolve #56 
Fix a typo in an argument from the `mlprimitives.text.TextCleaner` primitive.