### PR TITLE
Fix SingleLayerCNNImageClassifier annotation

### DIFF
--- a/mlblocks_pipelines/keras.Sequential.SingleLayerCNNImagelClassifier.json
+++ b/mlblocks_pipelines/keras.Sequential.SingleLayerCNNImagelClassifier.json
@@ -1,0 +1,33 @@
+{
+    "metadata": {
+        "name": "keras.Sequential.SingleLayerCNNImageClassifier",
+        "data_type": "image",
+        "task_type": "classification"
+    },
+    "validation": {
+        "dataset": "usps",
+        "context": {}
+    },
+    "primitives": [
+        "mlprimitives.counters.UniqueCounter",
+        "keras.Sequential.SingleLayerCNNImageClassifier"
+    ],
+    "input_names": {
+        "mlprimitives.counters.UniqueCounter#1": {
+            "X": "y"
+        }
+    },
+    "output_names": {
+        "mlprimitives.counters.UniqueCounter#1": {
+            "counts": "classes"
+        }
+    },
+    "init_params": {
+        "mlprimitives.counters.UniqueCounter#1": {
+            "add": 1
+        },
+        "keras.Sequential.SingleLayerCNNImageClassifier#1": {
+            "epochs": 5
+        }
+    }
+}

--- a/mlblocks_primitives/keras.Sequential.SingleLayerCNNImageClassifier.json
+++ b/mlblocks_primitives/keras.Sequential.SingleLayerCNNImageClassifier.json
@@ -110,7 +110,7 @@
                     {
                         "class": "keras.layers.Dense",
                         "parameters": {
-                            "units": "dense_units",
+                            "units": "classes",
                             "activation": "dense_activation"
                         }
                     }


### PR DESCRIPTION
Resolve #37 

Rename the `dense_units` hyperparameter to `classes` and add a pipeline to test the primitive.