### PR TITLE
Add primitive to count feature matrix columns

### DIFF
--- a/mlprimitives/custom/counters.py
+++ b/mlprimitives/custom/counters.py
@@ -61,3 +61,10 @@ class VocabularyCounter(Counter):
                 count = max(count, len(words))
 
         return count
+
+
+def count_features(X):
+    if len(X.shape) != 2:
+        raise ValueError('Only 2d arrays are supported')
+
+    return X.shape[1]

--- a/mlprimitives/jsons/mlprimitives.custom.counters.count_features.json
+++ b/mlprimitives/jsons/mlprimitives.custom.counters.count_features.json
@@ -1,0 +1,35 @@
+{
+    "name": "mlprimitives.custom.counters.count_features",
+    "contributors": [
+        "Carles Sala <csala@csail.mit.edu>"
+    ],
+    "description": "Count the number of features in a 2d feature matrix.",
+    "classifiers": {
+        "type": "preprocessor",
+        "subtype": "feature_extractor"
+    },
+    "modalities": [],
+    "primitive": "mlprimitives.custom.counters.count_features",
+    "fit": {
+        "args": [
+            {
+                "name": "X",
+                "type": "ndarray"
+            }
+        ]
+    },
+    "produce": {
+        "args": [
+            {
+                "name": "X",
+                "type": "ndarray"
+            }
+        ],
+        "output": [
+            {
+                "name": "features",
+                "type": "int"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Resolve #146 

Add `mlprimitives.custom.counters.count_features` primitive, which counts the columns in the feature matrix and returns the number as the `features` variable.