### PR TITLE
Issue 159 add keras.sequential callbacks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,16 +86,13 @@ install-develop: clean-build clean-pyc ## install the package in editable mode a
 
 .PHONY: lint
 lint: ## check style with flake8 and isort
-	find pipelines -name '*.json' | xargs -n1 -I{} bash -c "diff -q {} <(python -m json.tool {})"
-	find mlprimitives/jsons -name '*.json' | xargs -n1 -I{} bash -c "diff -q {} <(python -m json.tool {})"
 	flake8 mlprimitives tests
 	isort -c --recursive mlprimitives tests
+	find pipelines -name '*.json' | xargs -n1 -I{} bash -c "diff -q {} <(python -m json.tool {})"
+	find mlprimitives/jsons -name '*.json' | xargs -n1 -I{} bash -c "diff -q {} <(python -m json.tool {})"
 
 .PHONY: fix-lint
 fix-lint: ## fix lint issues using autoflake, autopep8, and isort
-	find pipelines -name '*.json' | xargs -n1 -I{} bash -c "python -m json.tool {} {}.tmp && mv {}.tmp {}"
-	find mlprimitives/jsons -name '*.json' | xargs -n1 -I{} bash -c "python -m json.tool {} {}.tmp && mv {}.tmp {}"
-
 	find mlprimitives -name '*.py' | xargs autoflake --in-place --remove-all-unused-imports --remove-unused-variables
 	autopep8 --in-place --recursive --aggressive mlprimitives
 	isort --apply --atomic --recursive mlprimitives
@@ -103,6 +100,9 @@ fix-lint: ## fix lint issues using autoflake, autopep8, and isort
 	find tests -name '*.py' | xargs autoflake --in-place --remove-all-unused-imports --remove-unused-variables
 	autopep8 --in-place --recursive --aggressive tests
 	isort --apply --atomic --recursive tests
+
+	find pipelines -name '*.json' | xargs -n1 -I{} bash -c "python -m json.tool {} {}.tmp && mv {}.tmp {}"
+	find mlprimitives/jsons -name '*.json' | xargs -n1 -I{} bash -c "python -m json.tool {} {}.tmp && mv {}.tmp {}"
 
 
 # TEST TARGETS

--- a/mlprimitives/cli.py
+++ b/mlprimitives/cli.py
@@ -17,7 +17,7 @@ LOGGER = logging.getLogger(__name__)
 
 def _logging_setup(verbosity=1):
     logger = logging.getLogger()
-    log_level = (3 - verbosity) * 10
+    log_level = (4 - verbosity) * 10
     fmt = '%(asctime)s - %(levelname)s - %(message)s'
     formatter = logging.Formatter(fmt)
     logger.setLevel(log_level)

--- a/mlprimitives/jsons/keras.Sequential.LSTMTextClassifier.json
+++ b/mlprimitives/jsons/keras.Sequential.LSTMTextClassifier.json
@@ -59,6 +59,10 @@
                 "type": "bool",
                 "default": true
             },
+            "verbose": {
+                "type": "bool",
+                "default": false
+            },
             "conv_activation": {
                 "type": "str",
                 "default": "relu"
@@ -84,6 +88,18 @@
             "epochs": {
                 "type": "int",
                 "default": 10
+            },
+            "callbacks": {
+                "type": "list",
+                "default": []
+            },
+            "validation_split": {
+                "type": "float",
+                "default": 0.0
+            },
+            "bastch_size": {
+                "type": "int",
+                "default": 32
             },
             "layers": {
                 "type": "list",

--- a/pipelines/keras.Sequential.LSTMTextClassifier.json
+++ b/pipelines/keras.Sequential.LSTMTextClassifier.json
@@ -1,0 +1,57 @@
+{
+    "metadata": {
+        "name": "keras.Sequential.LSTMTextClassifier",
+        "data_type": "text",
+        "task_type": "classification"
+    },
+    "validation": {
+        "dataset": "newsgroups"
+    },
+    "primitives": [
+        "mlprimitives.custom.counters.UniqueCounter",
+        "mlprimitives.custom.text.TextCleaner",
+        "mlprimitives.custom.counters.VocabularyCounter",
+        "keras.preprocessing.text.Tokenizer",
+        "keras.preprocessing.sequence.pad_sequences",
+        "keras.Sequential.LSTMTextClassifier"
+    ],
+    "input_names": {
+        "mlprimitives.custom.counters.UniqueCounter#1": {
+            "X": "y"
+        }
+    },
+    "output_names": {
+        "mlprimitives.custom.counters.UniqueCounter#1": {
+            "counts": "classes"
+        },
+        "mlprimitives.custom.counters.VocabularyCounter#1": {
+            "counts": "vocabulary_size"
+        }
+    },
+    "init_params": {
+        "mlprimitives.custom.counters.VocabularyCounter#1": {
+            "add": 1
+        },
+        "mlprimitives.custom.text.TextCleaner#1": {
+            "language": "en"
+        },
+        "keras.preprocessing.sequence.pad_sequences#1": {
+            "maxlen": 100
+        },
+        "keras.Sequential.LSTMTextClassifier#1": {
+            "input_length": 100,
+            "verbose": true,
+            "validation_split": 0.2,
+            "callbacks": [
+                {
+                    "class": "keras.callbacks.EarlyStopping",
+                    "args": {
+                        "monitor": "val_acc",
+                        "patience": 1,
+                        "min_delta": 0.01
+                    }
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
Resolve #159 
Resolve #161 

Add support for callbacks and some of the other fit arguments that were not supported.
Some arguments have been intentionally kept out because they do not fit entirely the MLBlocks arguments scenarios. They can be added in a later PR if they become necessary.

An LSTMTextClassifier pipeline has been added with an example that introduces an EarlyStopping Callback as an optional init_argument.