### PR TITLE
typo correction ref:bugfix-176

### DIFF
--- a/mlprimitives/jsons/keras.Sequential.LSTMTimeSeriesRegressor.json
+++ b/mlprimitives/jsons/keras.Sequential.LSTMTimeSeriesRegressor.json
@@ -71,7 +71,7 @@
                 "type": "float",
                 "default": 0.2
             },
-            "bastch_size": {
+            "batch_size": {
                 "type": "int",
                 "default": 64
             },


### PR DESCRIPTION
Corrected typo in keras.Sequential.LSTMTimeSeriesRegressor.json as per bug 176