### PR TITLE
Issue 180 improve find anomalies primitive

### DIFF
--- a/mlprimitives/custom/timeseries_anomalies.py
+++ b/mlprimitives/custom/timeseries_anomalies.py
@@ -14,14 +14,20 @@ def regression_errors(y, y_hat, smoothing_window=0.01, smooth=True):
     If smooth is True, apply EWMA to the resulting array of errors.
 
     Args:
-        y (array): Ground truth.
-        y_hat (array): Predicted values.
-        smoothing_window (float): Size of the smoothing window, expressed as a proportion
-            of the total length of y.
-        smooth (bool): Indicates whether the returned errors should be smoothed with EWMA.
+        y (ndarray):
+            Ground truth.
+        y_hat (ndarray):
+            Predicted values.
+        smoothing_window (float):
+            Optional. Size of the smoothing window, expressed as a proportion of the total
+            length of y. If not given, 0.01 is used.
+        smooth (bool):
+            Optional. Indicates whether the returned errors should be smoothed with EWMA.
+            If not given, `True` is used.
 
     Returns:
-        (array): Array of errors.
+        ndarray:
+            Array of errors.
     """
     errors = np.abs(y - y_hat)[:, 0]
 
@@ -40,14 +46,20 @@ def deltas(errors, epsilon, mean, std):
     delta_std = std(errors) - std(all errors below epsilon)
 
     Args:
-        errors (ndarray): Array of errors.
-        epsilon (ndarray): Threshold value.
-        mean (float): Mean of errors.
-        std (float): Standard deviation of errors.
+        errors (ndarray):
+            Array of errors.
+        epsilon (ndarray):
+            Threshold value.
+        mean (float):
+            Mean of errors.
+        std (float):
+            Standard deviation of errors.
 
     Returns:
-        (float): delta_mean.
-        (float): delta_std.
+        float:
+            delta_mean.
+        float:
+            delta_std.
     """
     below = errors[errors <= epsilon]
     if not len(below):
@@ -64,12 +76,16 @@ def count_above(errors, epsilon):
     which means that a sequence started at that position.
 
     Args:
-        errors (ndarray): Array of errors.
-        epsilon (ndarray): Threshold value.
+        errors (ndarray):
+            Array of errors.
+        epsilon (ndarray):
+            Threshold value.
 
     Returns:
-        (int): Number of errors above epsilon.
-        (int): Number of continuous sequences above epsilon.
+        int:
+            Number of errors above epsilon.
+        int:
+            Number of continuous sequences above epsilon.
     """
     above = errors > epsilon
     total_above = len(errors[above])
@@ -99,13 +115,18 @@ def z_cost(z, errors, mean, std):
     it into a cost function, as later on we will use scipy.fmin to minimize it.
 
     Args:
-        z (ndarray): Value for which a cost score is calculated.
-        errors (ndarray): Array of errors.
-        mean (float): Mean of errors.
-        std (float): Standard deviation of errors.
+        z (ndarray):
+            Value for which a cost score is calculated.
+        errors (ndarray):
+            Array of errors.
+        mean (float):
+            Mean of errors.
+        std (float):
+            Standard deviation of errors.
 
     Returns:
-        (float): Cost of z.
+        float:
+            Cost of z.
     """
     epsilon = mean + z * std
 
@@ -125,15 +146,18 @@ def _find_threshold(errors, z_range):
     """Find the ideal threshold.
 
     The ideal threshold is the one that minimizes the z_cost function. Scipy.fmin is used
-        to find the minimum, using the values from z_range as starting points.
+    to find the minimum, using the values from z_range as starting points.
 
     Args:
-        errors (ndarray): Array of errors.
-        z_range (list): List of two values denoting the range out of which the start points
-            for the scipy.fmin function are chosen.
+        errors (ndarray):
+            Array of errors.
+        z_range (list):
+            List of two values denoting the range out of which the start points for the
+            scipy.fmin function are chosen.
 
     Returns:
-        (float): Calculated threshold value.
+        float:
+            Calculated threshold value.
     """
     mean = errors.mean()
     std = errors.std()
@@ -163,14 +187,19 @@ def _find_sequences(errors, epsilon, anomaly_padding):
         * Consider a sequence end any point which was false and has changed.
 
     Args:
-        errors (ndarray): Array of errors.
-        epsilon (float): Threshold value. All errors above epsilon are considered an anomaly.
-        anomaly_padding (int): Number of errors before and after a found anomaly that are added
-            to the anomalous sequence.
+        errors (ndarray):
+            Array of errors.
+        epsilon (float):
+            Threshold value. All errors above epsilon are considered an anomaly.
+        anomaly_padding (int):
+            Number of errors before and after a found anomaly that are added to the
+            anomalous sequence.
 
     Returns:
-        (ndarray): Array containing start, end of each found anomalous sequence.
-        (float): Maximum error value that was not considered an anomaly.
+        ndarray:
+            Array containing start, end of each found anomalous sequence.
+        float:
+            Maximum error value that was not considered an anomaly.
     """
     above = pd.Series(errors > epsilon)
     index_above = np.argwhere(above)
@@ -206,13 +235,16 @@ def _get_max_errors(errors, sequences, max_below):
     indexes, sorted descendingly by the maximum error.
 
     Args:
-        errors (ndarray): Array of errors.
-        sequences (ndarray): Array containing start, end of anomalous sequences
-        max_below (float): Maximum error value that was not considered an anomaly.
+        errors (ndarray):
+            Array of errors.
+        sequences (ndarray):
+            Array containing start, end of anomalous sequences
+        max_below (float):
+            Maximum error value that was not considered an anomaly.
 
     Returns:
-        (pandas.DataFrame): DataFrame object containing columns ``start``, ``stop`` and
-            ``max_error``.
+        pandas.DataFrame:
+            DataFrame object containing columns ``start``, ``stop`` and ``max_error``.
     """
     max_errors = [{
         'max_error': max_below,
@@ -246,13 +278,15 @@ def _prune_anomalies(max_errors, min_percent):
         * Get the values of all the sequences above that index.
 
     Args:
-        max_errors (pandas.DataFrame): DataFrame object containing columns ``start``, ``stop``
-            and ``max_error``.
-        min_percent (float): Percentage of separation the anomalies need to meet between
-            themselves and the highest non-anomalous error in the window sequence.
+        max_errors (pandas.DataFrame):
+            DataFrame object containing columns ``start``, ``stop`` and ``max_error``.
+        min_percent (float):
+            Percentage of separation the anomalies need to meet between themselves and the
+            highest non-anomalous error in the window sequence.
 
     Returns:
-        (ndarray): Array containing start, end, max_error of the pruned anomalies.
+        ndarray:
+            Array containing start, end, max_error of the pruned anomalies.
     """
     next_error = max_errors['max_error'].shift(-1).iloc[:-1]
     max_error = max_errors['max_error'].iloc[:-1]
@@ -275,14 +309,19 @@ def _compute_scores(pruned_anomalies, errors, threshold, window_start):
     and add window_start timestamp to make the index absolute.
 
     Args:
-        pruned_anomalies (ndarray): Array of anomalies containing the start, end and max_error
-            for all anomalies in the window.
-        errors (ndarray): Array of errors.
-        threshold (float): Threshold value.
-        window_start (int): Index of the first error value in the window.
+        pruned_anomalies (ndarray):
+            Array of anomalies containing the start, end and max_error for all anomalies in
+            the window.
+        errors (ndarray):
+            Array of errors.
+        threshold (float):
+            Threshold value.
+        window_start (int):
+            Index of the first error value in the window.
 
     Returns:
-        (list): List of anomalies containing start-index, end-index, score for each anomaly.
+        list:
+            List of anomalies containing start-index, end-index, score for each anomaly.
     """
     anomalies = list()
     denominator = errors.mean() + errors.std()
@@ -304,12 +343,12 @@ def _merge_sequences(sequences):
     weighted by the length of the corresponding sequences.
 
     Args:
-        sequences (list): List of anomalies, containing start-index, end-index, score for
-            each anomaly.
+        sequences (list):
+            List of anomalies, containing start-index, end-index, score for each anomaly.
 
     Returns:
-        (ndarray): Array containing start-index, end-index, score for each anomaly after
-            merging.
+        ndarray:
+            Array containing start-index, end-index, score for each anomaly after merging.
     """
     if len(sequences) == 0:
         return np.array([])
@@ -344,17 +383,23 @@ def _find_window_sequences(window, z_range, anomaly_padding, min_percent, window
     score of the anomalies is computed.
 
     Args:
-        window (ndarray): Array of errors in the window that is analyzed.
-        z_range (list): List of two values denoting the range out of which the start
-            points for the dynamic find_threshold function are chosen.
-        anomaly_padding (int): Number of errors before and after a found anomaly that are added
-            to the anomalous sequence.
-        min_percent (float): Percentage of separation the anomalies need to meet between
-            themselves and the highest non-anomalous error in the window sequence.
-        window_start (integer): Index of the first error value in the window.
+        window (ndarray):
+            Array of errors in the window that is analyzed.
+        z_range (list):
+            List of two values denoting the range out of which the start points for the
+            dynamic find_threshold function are chosen.
+        anomaly_padding (int):
+            Number of errors before and after a found anomaly that are added to the anomalous
+            sequence.
+        min_percent (float):
+            Percentage of separation the anomalies need to meet between themselves and the
+            highest non-anomalous error in the window sequence.
+        window_start (int):
+            Index of the first error value in the window.
 
     Returns:
-        (ndarray): Array containing the start-index, end-index, score for each anomalous sequence
+        ndarray:
+            Array containing the start-index, end-index, score for each anomalous sequence
             that was found in the window.
     """
 
@@ -379,26 +424,33 @@ def find_anomalies(errors, index, z_range=(0, 10), window_size=None, window_step
     Lastly, we combine overlapping or consecutive sequences.
 
     Args:
-        errors (ndarray): Array of errors.
-        index (ndarray): Array of indices of the errors.
-        z_range (list, optional): List of two values denoting the range out of which the start
-            points for the scipy.fmin function are chosen. If not given, (0, 10) is used.
-        window_size (int, optional): Size of the window for which a threshold is calculated.
-            If not given, None is used, which finds one threshold for the entire sequence of
-            errors.
-        window_step_size (int, optional): Number of steps the window is moved before another
-            threshold is calculated for the new window.
-        min_percent (float, optional): Percentage of separation the anomalies need to meet
-            between themselves and the highest non-anomalous error in the window sequence.
-            It nof given, 0.1 is used.
-        anomaly_padding (int, optional): Number of errors before and after a found anomaly that
-            are added to the anomalous sequence. If not given, 50 is used.
-        lower_threshold (bool, optional): Indicates whether to apply a lower threshold to find
-            unusually low errors. If not given, False is used.
+        errors (ndarray):
+            Array of errors.
+        index (ndarray):
+            Array of indices of the errors.
+        z_range (list):
+            Optional. List of two values denoting the range out of which the start points for
+            the scipy.fmin function are chosen. If not given, (0, 10) is used.
+        window_size (int):
+            Optional. Size of the window for which a threshold is calculated. If not given,
+            `None` is used, which finds one threshold for the entire sequence of errors.
+        window_step_size (int):
+            Optional. Number of steps the window is moved before another threshold is
+            calculated for the new window.
+        min_percent (float):
+            Optional. Percentage of separation the anomalies need to meet between themselves and
+            the highest non-anomalous error in the window sequence. It nof given, 0.1 is used.
+        anomaly_padding (int):
+            Optional. Number of errors before and after a found anomaly that are added to the
+            anomalous sequence. If not given, 50 is used.
+        lower_threshold (bool):
+            Optional. Indicates whether to apply a lower threshold to find unusually low errors.
+            If not given, `False` is used.
 
     Returns:
-        (ndarray): Array containing start-index, end-index, score for each anomalous sequence
-            that was found.
+        ndarray:
+            Array containing start-index, end-index, score for each anomalous sequence that
+            was found.
     """
 
     window_size = window_size or len(errors)

--- a/mlprimitives/custom/timeseries_anomalies.py
+++ b/mlprimitives/custom/timeseries_anomalies.py
@@ -132,7 +132,7 @@ def _find_sequences(errors, epsilon, anomaly_interval):
     index_above = np.argwhere(above)
 
     for i in index_above.flatten():
-        above[max(0, i-anomaly_interval):min(i+anomaly_interval+1, len(above))] = True
+        above[max(0, i - anomaly_interval):min(i + anomaly_interval + 1, len(above))] = True
 
     shift = above.shift(1).fillna(False)
     change = above != shift
@@ -216,7 +216,7 @@ def _compute_scores(pruned_anomalies, errors, threshold, window_start):
     for row in pruned_anomalies:
         max_error = row[2]
         score = (max_error - threshold) / denominator
-        anomalies.append([row[0]+window_start, row[1]+window_start, score])
+        anomalies.append([row[0] + window_start, row[1] + window_start, score])
 
     return anomalies
 
@@ -242,21 +242,21 @@ def _merge_sequences(sequences):
             new_sequences.append(i)
         else:
             j = new_sequences[-1]
-            if i[0] <= j[1]+1:
+            if i[0] <= j[1] + 1:
                 score.append(i[2])
-                weights.append(i[1]-i[0])
+                weights.append(i[1] - i[0])
                 weighted_average = np.average(score, weights=weights)
                 new_sequences[-1] = (j[0], max(j[1], i[1]), weighted_average)
             else:
                 score = [i[2]]
-                weights = [i[1]-i[0]]
+                weights = [i[1] - i[0]]
                 new_sequences.append(i)
 
     return np.array(new_sequences)
 
 
-def find_anomalies(errors, index, z_range=(0, 10), window_size=None, window_step_size=None, min_percent=0.1,
-                   anomaly_interval=50, lower_threshold=False):
+def find_anomalies(errors, index, z_range=(0, 10), window_size=None, window_step_size=None,
+                   min_percent=0.1, anomaly_interval=50, lower_threshold=False):
     """Find sequences of values that are anomalous.
 
     We first find the ideal threshold for the set of errors that we have,
@@ -276,12 +276,11 @@ def find_anomalies(errors, index, z_range=(0, 10), window_size=None, window_step
     while window_end < len(errors):
         window_end = window_start + window_size
         window = errors[window_start:window_end]
-
         threshold = _find_threshold(window, z_range)
         window_sequences, max_below = _find_sequences(window, threshold, anomaly_interval)
         max_errors = _get_max_errors(window, window_sequences, max_below)
         pruned_anomalies = _prune_anomalies(max_errors, min_percent)
-        window_sequences = _compute_scores(pruned_anomalies, errors, threshold, window_start)
+        window_sequences = _compute_scores(pruned_anomalies, window, threshold, window_start)
         sequences.extend(window_sequences)
 
         if lower_threshold:
@@ -291,10 +290,11 @@ def find_anomalies(errors, index, z_range=(0, 10), window_size=None, window_step
 
             # Perform same procedure as above
             threshold = _find_threshold(inverted_window, z_range)
-            window_sequences, max_below = _find_sequences(inverted_window, threshold, anomaly_interval)
+            window_sequences, max_below = _find_sequences(inverted_window, threshold,
+                                                          anomaly_interval)
             max_errors = _get_max_errors(inverted_window, window_sequences, max_below)
             pruned_anomalies = _prune_anomalies(max_errors, min_percent)
-            window_sequences = _compute_scores(pruned_anomalies, errors, threshold, window_start)
+            window_sequences = _compute_scores(pruned_anomalies, window, threshold, window_start)
             sequences.extend(window_sequences)
 
         window_start = window_start + window_step_size

--- a/mlprimitives/jsons/mlprimitives.custom.timeseries_anomalies.find_anomalies.json
+++ b/mlprimitives/jsons/mlprimitives.custom.timeseries_anomalies.find_anomalies.json
@@ -42,7 +42,15 @@
             },
             "window_size": {
                 "type": "int",
-                "default": null
+                "default": 2000
+            },
+            "window_step_size": {
+                "type": "int",
+                "default": 200
+            },
+            "lower_threshold": {
+                "type": "bool",
+                "default": false
             }
         },
         "tunable": {
@@ -52,6 +60,14 @@
                 "range": [
                     0.01,
                     0.9
+                ]
+            },
+            "anomaly_interval": {
+                "type": "int",
+                "default": 50,
+                "range": [
+                    0,
+                    400
                 ]
             }
         }

--- a/mlprimitives/jsons/mlprimitives.custom.timeseries_anomalies.find_anomalies.json
+++ b/mlprimitives/jsons/mlprimitives.custom.timeseries_anomalies.find_anomalies.json
@@ -62,7 +62,7 @@
                     0.9
                 ]
             },
-            "anomaly_interval": {
+            "anomaly_padding": {
                 "type": "int",
                 "default": 50,
                 "range": [

--- a/tests/custom/test_timeseries_anomalies.py
+++ b/tests/custom/test_timeseries_anomalies.py
@@ -6,7 +6,7 @@ from numpy.testing import assert_allclose
 from pandas.testing import assert_frame_equal
 
 from mlprimitives.custom.timeseries_anomalies import (
-    _find_sequences, _get_max_errors, _prune_anomalies, find_anomalies)
+    _find_sequences, _get_max_errors, _merge_sequences, _prune_anomalies, find_anomalies)
 
 
 class GetMaxErrorsTest(TestCase):
@@ -64,7 +64,7 @@ class PruneAnomaliesTest(TestCase):
         max_errors = pd.DataFrame([
             [0.1, -1, -1]
         ], columns=['max_error', 'start', 'stop'])
-        expected = np.ndarray((0, 2))
+        expected = np.ndarray((0, 3))
         self._run(max_errors, expected)
 
     def test_no_anomalies(self):
@@ -72,7 +72,7 @@ class PruneAnomaliesTest(TestCase):
             [0.11, 1, 2],
             [0.1, -1, -1]
         ], columns=['max_error', 'start', 'stop'])
-        expected = np.ndarray((0, 2))
+        expected = np.ndarray((0, 3))
         self._run(max_errors, expected)
 
     def test_one_anomaly(self):
@@ -81,7 +81,7 @@ class PruneAnomaliesTest(TestCase):
             [0.1, -1, -1]
         ], columns=['max_error', 'start', 'stop'])
         expected = np.array([
-            [1, 2]
+            [1, 2, 0.2]
         ])
         self._run(max_errors, expected)
 
@@ -92,8 +92,8 @@ class PruneAnomaliesTest(TestCase):
             [0.1, -1, -1]
         ], columns=['max_error', 'start', 'stop'])
         expected = np.array([
-            [1, 2],
-            [4, 5]
+            [1, 2, 0.3],
+            [4, 5, 0.2]
         ])
         self._run(max_errors, expected)
 
@@ -105,8 +105,8 @@ class PruneAnomaliesTest(TestCase):
             [0.1, -1, -1]
         ], columns=['max_error', 'start', 'stop'])
         expected = np.array([
-            [1, 2],
-            [4, 5]
+            [1, 2, 0.3],
+            [4, 5, 0.22]
         ])
         self._run(max_errors, expected)
 
@@ -118,9 +118,9 @@ class PruneAnomaliesTest(TestCase):
             [0.1, -1, -1]
         ], columns=['max_error', 'start', 'stop'])
         expected = np.array([
-            [1, 2],
-            [4, 5],
-            [7, 8]
+            [1, 2, 0.3],
+            [4, 5, 0.21],
+            [7, 8, 0.2]
         ])
         self._run(max_errors, expected)
 
@@ -128,9 +128,11 @@ class PruneAnomaliesTest(TestCase):
 class FindSequencesTest(TestCase):
 
     THRESHOLD = 0.5
+    ANOMALY_INTERVAL = 1
 
     def _run(self, errors, expected, expected_max):
-        found, max_below = _find_sequences(np.asarray(errors), self.THRESHOLD)
+        found, max_below = _find_sequences(np.asarray(errors), self.THRESHOLD,
+                                           self.ANOMALY_INTERVAL)
 
         np.testing.assert_array_equal(found, expected)
         assert max_below == expected_max
@@ -142,28 +144,57 @@ class FindSequencesTest(TestCase):
         self._run([1, 1, 1, 1], [(0, 3)], 0)
 
     def test__find_sequences_open_end(self):
-        self._run([0, 1, 1, 1], [(1, 3)], 0)
+        self._run([0, 0, 0.4, 1, 1, 1], [(2, 5)], 0)
 
     def test__find_sequences_open_start(self):
-        self._run([1, 1, 1, 0], [(0, 2)], 0)
+        self._run([1, 1, 1, 0.4, 0, 0], [(0, 3)], 0)
 
     def test__find_sequences_middle(self):
-        self._run([0, 1, 1, 0], [(1, 2)], 0)
+        self._run([0, 0, 1, 1, 0, 0], [(1, 4)], 0)
 
-    def test__find_sequences_stop_length_one(self):
-        self._run([1, 0, 1, 1], [(0, 0), (2, 3)], 0)
+    def test__find_sequences_stop(self):
+        self._run([1, 0, 0, 0, 1, 1], [(0, 1), (3, 5)], 0)
 
-    def test__find_sequences_open_length_one(self):
-        self._run([1, 0, 0, 1], [(0, 0), (3, 3)], 0)
+
+class MergeSequencesTest(TestCase):
+
+    def _run(self, sequences, expected):
+        merged_sequences = _merge_sequences(sequences)
+
+        np.testing.assert_array_equal(merged_sequences, expected)
+
+    def test__merge_sequences_consecutive(self):
+        self._run([(1, 2, 0.5), (3, 4, 0.5)], [(1, 4, 0.5)])
+
+    def test__merge_sequences_start_overlap(self):
+        self._run([(1, 3, 0.5), (2, 4, 0.5)], [(1, 4, 0.5)])
+
+    def test__merge_sequences_start_end_overlap(self):
+        self._run([(1, 4, 0.5), (2, 3, 0.5)], [(1, 4, 0.5)])
+
+    def test__merge_sequences_non_consecutive(self):
+        self._run([(1, 2, 0.5), (4, 5, 0.5)], [(1, 2, 0.5), (4, 5, 0.5)])
+
+    def test__merge_sequences_consecutive_different_score(self):
+        self._run([(1, 2, 1.0), (3, 4, 0.5)], [(1, 4, 0.75)])
+
+    def test__merge_sequences_consecutive_different_score_and_length(self):
+        self._run([(1, 2, 1.0), (3, 4, 0.5)], [(1, 4, 0.75)])
 
 
 class FindAnomaliesTest(TestCase):
 
     THRESHOLD = 0.5
-    INDEX = [10, 11, 12, 13]
+    INDEX_SHORT = [1, 2, 3, 4]
+    INDEX_LONG = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    ANOMALY_INTERVAL = 1
 
-    def _run(self, errors, expected):
-        found = find_anomalies(np.asarray(errors), self.INDEX)
+    def _run(self, errors, expected, index=INDEX_SHORT, window_size=None,
+             window_step_size=None, lower_threshold=False):
+        found = find_anomalies(np.asarray(errors), index=index,
+                               anomaly_interval=self.ANOMALY_INTERVAL,
+                               window_size=window_size, window_step_size=window_step_size,
+                               lower_threshold=lower_threshold)
 
         assert_allclose(found, expected)
 
@@ -171,14 +202,26 @@ class FindAnomaliesTest(TestCase):
         self._run([0, 0, 0, 0], np.array([]))
 
     def test_find_anomalies_one_anomaly(self):
-        self._run([0, 0.5, 0.5, 0], np.array([[11., 12., 0.025]]))
+        self._run([0, 0.5, 0.5, 0], np.array([[1., 4., 0.025]]))
 
     def test_find_anomalies_open_start(self):
-        self._run([0.5, 0.5, 0, 0], np.array([[10., 11., 0.025]]))
+        self._run([0.5, 0.5, 0, 0], np.array([[1., 3., 0.025]]))
 
     def test_find_anomalies_open_end(self):
-        self._run([0, 0, 0.5, 0.5], np.array([[12., 13., 0.025]]))
+        self._run([0, 0, 0.5, 0.5], np.array([[2., 4., 0.025]]))
 
     def test_find_anomalies_two_anomalies(self):
-        self._run([0.5, 0, 0.5, 0], np.array([[10., 10., 0.025], [12., 12., 0.025]]))
-        self._run([0., 0.5, 0., 0.5], np.array([[11., 11., 0.025], [13., 13., 0.025]]))
+        self._run([0.5, 0, 0.5, 0], np.array([[1., 4., 0.025]]))
+        self._run([0, 0.5, 0, 0.5], np.array([[1., 4., 0.025]]))
+
+    def test_find_anomalies_multiple_non_overlapping_thresholds(self):
+        self._run([0, 0, 0.5, 0.5, 0, 0, 0.5, 0.5, 0, 0],
+                  np.array([[2., 4., 0.025], [6., 8., 0.025]]), index=self.INDEX_LONG,
+                  window_size=4, window_step_size=4)
+
+    def test_find_anomalies_multiple_overlapping_thresholds(self):
+        self._run([0, 0, 0.5, 0.5, 0, 0, 0.5, 0.5, 0, 0], np.array([[2., 9., 0.025]]),
+                  index=self.INDEX_LONG, window_size=4, window_step_size=2)
+
+    def test_find_anomalies_lower_threshold(self):
+        self._run([0.5, 0.5, 0, 0], np.array([[1., 4., 0.025]]), lower_threshold=True)

--- a/tests/custom/test_timeseries_anomalies.py
+++ b/tests/custom/test_timeseries_anomalies.py
@@ -128,11 +128,11 @@ class PruneAnomaliesTest(TestCase):
 class FindSequencesTest(TestCase):
 
     THRESHOLD = 0.5
-    ANOMALY_INTERVAL = 1
+    ANOMALY_PADDING = 1
 
     def _run(self, errors, expected, expected_max):
         found, max_below = _find_sequences(np.asarray(errors), self.THRESHOLD,
-                                           self.ANOMALY_INTERVAL)
+                                           self.ANOMALY_PADDING)
 
         np.testing.assert_array_equal(found, expected)
         assert max_below == expected_max
@@ -187,12 +187,12 @@ class FindAnomaliesTest(TestCase):
     THRESHOLD = 0.5
     INDEX_SHORT = [1, 2, 3, 4]
     INDEX_LONG = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-    ANOMALY_INTERVAL = 1
+    ANOMALY_PADDING = 1
 
     def _run(self, errors, expected, index=INDEX_SHORT, window_size=None,
              window_step_size=None, lower_threshold=False):
         found = find_anomalies(np.asarray(errors), index=index,
-                               anomaly_interval=self.ANOMALY_INTERVAL,
+                               anomaly_padding=self.ANOMALY_PADDING,
                                window_size=window_size, window_step_size=window_step_size,
                                lower_threshold=lower_threshold)
 


### PR DESCRIPTION
Addresses the changes mentioned in #180 to improve the `custom.timeseries_anomalies.find_anomalies` primitive

- Add optional threshold for unusually low errors
- Add possibility to use overlapping thresholds
- Once an anomalous region is found, increase the region by a predefined size  to make the pruning afterwards more stable
- Fix the calculation of anomaly score to work with consecutive and overlapping sequences