### PR TITLE
Curate PCA primitive hyperparameters

### DIFF
--- a/mlprimitives/primitives/sklearn.decomposition.PCA.json
+++ b/mlprimitives/primitives/sklearn.decomposition.PCA.json
@@ -41,9 +41,21 @@
             "copy": {
                 "type": "bool",
                 "default": true
+            },
+            "random_state": {
+                "type": "int",
+                "default": null
             }
         },
         "tunable": {
+            "n_components": {
+                "type": "int",
+                "default": null,
+                "range": [
+                    1,
+                    500
+                ]
+            },
             "tol": {
                 "type": "float",
                 "default": 0.0,


### PR DESCRIPTION
Resolve #190

Add the following two hyperparameters to the `sklearn.decomposition.PCA` primitive: `n_components` and `random_state`