### PR TITLE
Issue 232 add range scaler and unscaler

### DIFF
--- a/mlprimitives/custom/preprocessing.py
+++ b/mlprimitives/custom/preprocessing.py
@@ -28,3 +28,41 @@ class ClassDecoder():
 
     def decode(self, y):
         return self._label_encoder.inverse_transform(y)
+
+
+class RangeScaler():
+
+    _data_min = None
+    _data_scale = None
+    _data_range = None
+
+    def __init__(self, out_min, out_max):
+        self._out_min = out_min
+        self._out_scale = out_max - out_min
+
+    def fit(self, X):
+        data_max = X.max(axis=0)
+        self._data_min = X.min(axis=0)
+        self._data_scale = data_max - self._data_min
+        self._data_range = (self._data_min, data_max)
+
+    def scale(self, X):
+        scaled = (X - self._data_min) / self._data_scale
+        rescaled = (scaled * self._out_scale) + self._out_min
+
+        return rescaled, self._data_range
+
+
+class RangeUnscaler():
+
+    def __init__(self, out_min, out_max):
+        self._out_min = out_min
+        self._out_scale = out_max - out_min
+
+    def fit(self, data_range):
+        self._data_min = data_range[0]
+        self._data_scale = data_range[1] - self._data_min
+
+    def unscale(self, X):
+        unscaled = (X - self._out_min) / self._out_scale
+        return (unscaled * self._data_scale) + self._data_min

--- a/mlprimitives/primitives/mlprimitives.custom.preprocessing.RangeScaler.json
+++ b/mlprimitives/primitives/mlprimitives.custom.preprocessing.RangeScaler.json
@@ -1,0 +1,53 @@
+{
+    "name": "mlprimitives.custom.preprocessing.RangeScaler",
+    "contributors": [
+        "Carles Sala <csala@csail.mit.edu>"
+    ],
+    "description": "Scale data to a specified range.",
+    "classifiers": {
+        "type": "preprocessor",
+        "subtype": "scaler"
+    },
+    "modalities": [],
+    "primitive": "mlprimitives.custom.preprocessing.RangeScaler",
+    "fit": {
+        "method": "fit",
+        "args": [
+            {
+                "name": "X",
+                "type": "ndarray"
+            }
+        ]
+    },
+    "produce": {
+        "method": "scale",
+        "args": [
+            {
+                "name": "X",
+                "type": "ndarray"
+            }
+        ],
+        "output": [
+            {
+                "name": "X",
+                "type": "ndarray"
+            },
+            {
+                "name": "data_range",
+                "type": "ndarray"
+            }
+        ]
+    },
+    "hyperparameters": {
+        "fixed": {
+            "out_min": {
+                "type": "float",
+                "default": -1
+            },
+            "out_max": {
+                "type": "float",
+                "default": 1
+            }
+        }
+    }
+}

--- a/mlprimitives/primitives/mlprimitives.custom.preprocessing.RangeUnscaler.json
+++ b/mlprimitives/primitives/mlprimitives.custom.preprocessing.RangeUnscaler.json
@@ -1,0 +1,49 @@
+{
+    "name": "mlprimitives.custom.preprocessing.RangeUnscaler",
+    "contributors": [
+        "Carles Sala <csala@csail.mit.edu>"
+    ],
+    "description": "Uncale data from the specified range.",
+    "classifiers": {
+        "type": "preprocessor",
+        "subtype": "unscaler"
+    },
+    "modalities": [],
+    "primitive": "mlprimitives.custom.preprocessing.RangeUnscaler",
+    "fit": {
+        "method": "fit",
+        "args": [
+            {
+                "name": "data_range",
+                "type": "ndarray"
+            }
+        ]
+    },
+    "produce": {
+        "method": "unscale",
+        "args": [
+            {
+                "name": "X",
+                "type": "ndarray"
+            }
+        ],
+        "output": [
+            {
+                "name": "X",
+                "type": "ndarray"
+            }
+        ]
+    },
+    "hyperparameters": {
+        "fixed": {
+            "out_min": {
+                "type": "float",
+                "default": -1
+            },
+            "out_max": {
+                "type": "float",
+                "default": 1
+            }
+        }
+    }
+}

--- a/mlprimitives/primitives/mlprimitives.custom.preprocessing.RangeUnscaler.json
+++ b/mlprimitives/primitives/mlprimitives.custom.preprocessing.RangeUnscaler.json
@@ -3,7 +3,7 @@
     "contributors": [
         "Carles Sala <csala@csail.mit.edu>"
     ],
-    "description": "Uncale data from the specified range.",
+    "description": "Unscale data from the specified range.",
     "classifiers": {
         "type": "preprocessor",
         "subtype": "unscaler"

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ install_requires = [
     'numpy>=1.15.2,<1.17',
     'opencv-python>=3.4.0.12,<5',
     'pandas>=0.23.4,<0.25',
-    'python-dateutil>=2.1,<2.8.1',    # required by botocore
     'python-louvain>=0.10,<0.14',
     'scikit-image>=0.13.1,<0.15,!=0.14.3',
     'scikit-learn>=0.20.0,<0.21',
@@ -36,6 +35,7 @@ install_requires = [
     'statsmodels>=0.9.0,<1',
     'tensorflow>=1.11.0,<2',
     'xgboost>=0.72.1,<1',
+    'docutils>=0.10,<0.16',    # required by botocore
 ]
 
 

--- a/tests/custom/test_preprocessing.py
+++ b/tests/custom/test_preprocessing.py
@@ -1,0 +1,86 @@
+import unittest
+
+import numpy as np
+
+from mlprimitives.custom.preprocessing import RangeScaler, RangeUnscaler
+
+
+class RangeScalerTest(unittest.TestCase):
+
+    def test_fit(self):
+        scaler = RangeScaler(0, 1)
+
+        data = np.array([
+            [1, 2],
+            [2, 4],
+            [3, 6],
+            [2, 8],
+            [3, 10],
+        ])
+        scaler.fit(data)
+
+        np.testing.assert_equal(scaler._data_min, np.array([1, 2]))
+        np.testing.assert_equal(scaler._data_scale, np.array([2, 8]))
+        np.testing.assert_equal(scaler._data_range, (np.array([1, 2]), np.array([3, 10])))
+
+    def test_scale(self):
+        scaler = RangeScaler(0, 1)
+        scaler._data_min = np.array([1, 2])
+        scaler._data_scale = np.array([2, 8])
+        scaler._data_range = (np.array([1, 2]), np.array([3, 10]))
+
+        data = np.array([
+            [1, 2],
+            [2, 4],
+            [3, 6],
+            [2, 8],
+            [3, 10]
+        ])
+        scaled = scaler.scale(data)
+
+        expected = (
+            np.array([
+                [0, 0],
+                [0.5, 0.25],
+                [1, 0.5],
+                [0.5, 0.75],
+                [1, 1],
+            ]),
+            (np.array([1, 2]), np.array([3, 10]))
+        )
+        np.testing.assert_equal(scaled, expected)
+
+
+class RangeiUnscalerTest(unittest.TestCase):
+
+    def test_fit(self):
+        unscaler = RangeUnscaler(0, 1)
+
+        data_range = (np.array([1, 2]), np.array([3, 10]))
+        unscaler.fit(data_range)
+
+        np.testing.assert_equal(unscaler._data_min, np.array([1, 2]))
+        np.testing.assert_equal(unscaler._data_scale, np.array([2, 8]))
+
+    def test_unscale(self):
+        unscaler = RangeUnscaler(0, 1)
+        unscaler._data_min = np.array([1, 2])
+        unscaler._data_scale = np.array([2, 8])
+
+        data = np.array([
+            [0, 0],
+            [0.5, 0.25],
+            [1, 0.5],
+            [0.5, 0.75],
+            [1, 1],
+        ])
+        unscaled = unscaler.unscale(data)
+
+        expected = np.array([
+            [1, 2],
+            [2, 4],
+            [3, 6],
+            [2, 8],
+            [3, 10]
+        ])
+        np.testing.assert_equal(unscaled, expected)


### PR DESCRIPTION
Resolve #232 

Add `mlprimitives.custom.preprocessing.RangeScaler` and `mlprimitives.custom.preprocessing.RangeUnscaler` primitives and tests.