### PR TITLE
Accept timedelta and string in window_size in cutoff_window_sequences

### DIFF
--- a/mlprimitives/custom/timeseries_preprocessing.py
+++ b/mlprimitives/custom/timeseries_preprocessing.py
@@ -244,19 +244,18 @@ def cutoff_window_sequences(X, timeseries, window_size, cutoff_time=None, time_i
     for idx, row in enumerate(X.itertuples()):
         selected = timeseries[timeseries.index < row.Index]
 
-        if not isinstance(window_size, int):
-            min_time = selected.index[-1] - window_size
-            selected = selected.loc[selected.index > min_time]
-        else:
-            selected = selected.iloc[-window_size:]
-
         mask = [True] * len(selected)
         for column in columns:
             mask &= selected.pop(column) == getattr(row, column)
 
         selected = selected[mask]
-        selected = selected.iloc[-window_size:]
-
+        
+        if not isinstance(window_size, int):
+            min_time = selected.index[-1] - window_size
+            selected = selected.loc[selected.index > min_time]
+        else:
+            selected = selected.iloc[-window_size:]
+        
         len_selected = len(selected)
         if (len_selected != window_size):
             warnings.warn((

--- a/mlprimitives/custom/timeseries_preprocessing.py
+++ b/mlprimitives/custom/timeseries_preprocessing.py
@@ -213,7 +213,7 @@ def cutoff_window_sequences(X, timeseries, window_size, cutoff_time=None, time_i
         timeseries (pandas.DataFrame):
             ``pandas.DataFrame`` containing the actual timeseries data. The time index
             and either be set as the DataFrame index or as a column.
-        window_size (int):
+        window_size (int, str or Timedelta):
             Numer of elements to take before the cutoff time for each sequence.
         cutoff_time (str):
             Optional. If given, the indicated column will be used as the cutoff time.
@@ -245,16 +245,20 @@ def cutoff_window_sequences(X, timeseries, window_size, cutoff_time=None, time_i
         selected = timeseries[timeseries.index < row.Index]
 
         mask = [True] * len(selected)
+
         for column in columns:
             mask &= selected.pop(column) == getattr(row, column)
 
         selected = selected[mask]
+
         if not isinstance(window_size, int):
             min_time = selected.index[-1] - window_size
             selected = selected.loc[selected.index > min_time]
         else:
             selected = selected.iloc[-window_size:]
+
         len_selected = len(selected)
+
         if (len_selected != window_size):
             warnings.warn((
                 'Sequence shorter than window_size found: {} < {}. '

--- a/mlprimitives/custom/timeseries_preprocessing.py
+++ b/mlprimitives/custom/timeseries_preprocessing.py
@@ -214,7 +214,9 @@ def cutoff_window_sequences(X, timeseries, window_size, cutoff_time=None, time_i
             ``pandas.DataFrame`` containing the actual timeseries data. The time index
             and either be set as the DataFrame index or as a column.
         window_size (int, str or Timedelta):
-            Numer of elements to take before the cutoff time for each sequence.
+            If an integer is passed, it is the number of elements to take before the
+            cutoff time for each sequence. If a string or a Timedelta object is passed,
+            it is the period of time we take the elements from.
         cutoff_time (str):
             Optional. If given, the indicated column will be used as the cutoff time.
             Otherwise, the table index will be used.
@@ -245,7 +247,6 @@ def cutoff_window_sequences(X, timeseries, window_size, cutoff_time=None, time_i
         selected = timeseries[timeseries.index < row.Index]
 
         mask = [True] * len(selected)
-
         for column in columns:
             mask &= selected.pop(column) == getattr(row, column)
 
@@ -258,7 +259,6 @@ def cutoff_window_sequences(X, timeseries, window_size, cutoff_time=None, time_i
             selected = selected.iloc[-window_size:]
 
         len_selected = len(selected)
-
         if (len_selected != window_size):
             warnings.warn((
                 'Sequence shorter than window_size found: {} < {}. '

--- a/mlprimitives/custom/timeseries_preprocessing.py
+++ b/mlprimitives/custom/timeseries_preprocessing.py
@@ -237,9 +237,18 @@ def cutoff_window_sequences(X, timeseries, window_size, cutoff_time=None, time_i
 
     columns = list(X.columns)
 
+    if not isinstance(window_size, int):
+        window_size = pd.to_timedelta(window_size)
+
     output = list()
     for idx, row in enumerate(X.itertuples()):
         selected = timeseries[timeseries.index < row.Index]
+
+        if not isinstance(window_size, int):
+            min_time = selected.index[-1] - window_size
+            selected = selected.loc[selected.index > min_time]
+        else:
+            selected = selected.iloc[-window_size:]
 
         mask = [True] * len(selected)
         for column in columns:

--- a/mlprimitives/custom/timeseries_preprocessing.py
+++ b/mlprimitives/custom/timeseries_preprocessing.py
@@ -253,7 +253,7 @@ def cutoff_window_sequences(X, timeseries, window_size, cutoff_time=None, time_i
             min_time = selected.index[-1] - window_size
             selected = selected.loc[selected.index > min_time]
         else:
-            selected = selected.iloc[-window_size:]  
+            selected = selected.iloc[-window_size:]
         len_selected = len(selected)
         if (len_selected != window_size):
             warnings.warn((

--- a/mlprimitives/custom/timeseries_preprocessing.py
+++ b/mlprimitives/custom/timeseries_preprocessing.py
@@ -249,13 +249,11 @@ def cutoff_window_sequences(X, timeseries, window_size, cutoff_time=None, time_i
             mask &= selected.pop(column) == getattr(row, column)
 
         selected = selected[mask]
-        
         if not isinstance(window_size, int):
             min_time = selected.index[-1] - window_size
             selected = selected.loc[selected.index > min_time]
         else:
-            selected = selected.iloc[-window_size:]
-        
+            selected = selected.iloc[-window_size:]  
         len_selected = len(selected)
         if (len_selected != window_size):
             warnings.warn((

--- a/tests/custom/test_timeseries_preprocessing.py
+++ b/tests/custom/test_timeseries_preprocessing.py
@@ -2,12 +2,11 @@ from unittest import TestCase
 
 import numpy as np
 import pandas as pd
-import pytest
 from numpy.testing import assert_allclose
 
 from mlprimitives.custom.timeseries_preprocessing import (
-    intervals_to_mask, rolling_window_sequences, time_segments_aggregate,
-    time_segments_average, cutoff_window_sequences)
+    cutoff_window_sequences, intervals_to_mask, rolling_window_sequences, time_segments_aggregate,
+    time_segments_average)
 
 
 class IntervalsToMaskTest(TestCase):
@@ -241,10 +240,10 @@ class TimeSegmentsAggregateTest(TestCase):
         expected_index = np.array([1, 3])
         self._run(X, interval, expected_values, expected_index, time_column=0,
                   method=['mean', 'median'])
-        
-        
+
+
 class CutoffWindowSequencesTest(TestCase):
-    
+
     def setUp(self):
         self.X = pd.DataFrame({
             'id': [1, 2],
@@ -260,12 +259,12 @@ class CutoffWindowSequencesTest(TestCase):
             'value2': np.arange(21, 41),
             'id': [1] * 10 + [2] * 10
         }).set_index('timestamp')
-        
+
     def test_cutoff_time_column(self):
         # setup
         timeseries = self.timeseries
         X = self.X.reset_index()
-        
+
         # run
         array = cutoff_window_sequences(
             X,
@@ -273,21 +272,21 @@ class CutoffWindowSequencesTest(TestCase):
             window_size=3,
             cutoff_time='cutoff',
         )
-        
+
         # assert
-        expected_array = np.array([[[ 2, 22],
-                            [ 3, 23],
-                            [ 4, 24]],
-                            [[14, 34],
-                            [15, 35],
-                            [16, 36]]])
-        assert_allclose(array,expected_array)
-    
+        expected_array = np.array([[[2, 22],
+                                    [3, 23],
+                                    [4, 24]],
+                                   [[14, 34],
+                                    [15, 35],
+                                    [16, 36]]])
+        assert_allclose(array, expected_array)
+
     def test_time_index_column(self):
         # setup
         X = self.X
         timeseries = self.timeseries.reset_index()
-        
+
         # run
         array = cutoff_window_sequences(
             X,
@@ -295,63 +294,63 @@ class CutoffWindowSequencesTest(TestCase):
             window_size=3,
             time_index='timestamp',
         )
-        
+
         # assert
-        expected_array = np.array([[[ 2, 22],
-                            [ 3, 23],
-                            [ 4, 24]],
-                            [[14, 34],
-                            [15, 35],
-                            [16, 36]]])
-        assert_allclose(array,expected_array)
-        
+        expected_array = np.array([[[2, 22],
+                                    [3, 23],
+                                    [4, 24]],
+                                   [[14, 34],
+                                    [15, 35],
+                                    [16, 36]]])
+        assert_allclose(array, expected_array)
+
     def test_window_size_integer(self):
         # setup
         X = self.X
         timeseries = self.timeseries
-        
+
         # run
         array = cutoff_window_sequences(
             X,
             timeseries,
             window_size=3,
         )
-        
+
         # assert
-        expected_array = np.array([[[ 2, 22],
-                            [ 3, 23],
-                            [ 4, 24]],
-                            [[14, 34],
-                            [15, 35],
-                            [16, 36]]])
-        assert_allclose(array,expected_array)
-    
+        expected_array = np.array([[[2, 22],
+                                    [3, 23],
+                                    [4, 24]],
+                                   [[14, 34],
+                                    [15, 35],
+                                    [16, 36]]])
+        assert_allclose(array, expected_array)
+
     def test_window_size_string(self):
         # setup
         X = self.X
         timeseries = self.timeseries
-        
+
         # run
         array = cutoff_window_sequences(
             X,
             timeseries,
             window_size='3d',
         )
-        
+
         # assert
-        expected_array = np.array([[[ 2, 22],
-                            [ 3, 23],
-                            [ 4, 24]],
-                            [[14, 34],
-                            [15, 35],
-                            [16, 36]]])
-        assert_allclose(array,expected_array)
-    
+        expected_array = np.array([[[2, 22],
+                                    [3, 23],
+                                    [4, 24]],
+                                   [[14, 34],
+                                    [15, 35],
+                                    [16, 36]]])
+        assert_allclose(array, expected_array)
+
     def test_window_size_timedelta(self):
         # setup
         X = self.X
         timeseries = self.timeseries
-        
+
         # run
         array = cutoff_window_sequences(
             X,
@@ -360,103 +359,120 @@ class CutoffWindowSequencesTest(TestCase):
         )
 
         # assert
-        expected_array = np.array([[[ 2, 22],
-                            [ 3, 23],
-                            [ 4, 24]],
-                            [[14, 34],
-                            [15, 35],
-                            [16, 36]]])
-        assert_allclose(array,expected_array)
-        
-    @pytest.mark.xfail       
+        expected_array = np.array([[[2, 22],
+                                    [3, 23],
+                                    [4, 24]],
+                                   [[14, 34],
+                                    [15, 35],
+                                    [16, 36]]])
+        assert_allclose(array, expected_array)
+
     def test_large_window_size(self):
         # setup
         X = self.X
         timeseries = self.timeseries
-        
+
         # run
         array = cutoff_window_sequences(
             X,
             timeseries,
             window_size=5,
         )
-        
+
         # assert
-        expected_array = np.array([np.array([[ 1, 21],
-                            [ 2, 22],
-                            [ 3, 23],
-                            [ 4, 24]]),
-                            np.array([[12, 32],
-                            [13, 33],
-                            [14, 34],
-                            [15, 35],
-                            [16, 36]])])
-        assert_allclose(array, expected_array)
-        
-    @pytest.mark.xfail       
+        assert len(array) == 2
+        assert_allclose(
+            array[0],
+            np.array([
+                [1, 21],
+                [2, 22],
+                [3, 23],
+                [4, 24]
+            ])
+        )
+        assert_allclose(
+            array[1],
+            np.array([
+                [12, 32],
+                [13, 33],
+                [14, 34],
+                [15, 35],
+                [16, 36]
+            ])
+        )
+
     def test_window_size_zero(self):
         # setup
         X = self.X
         timeseries = self.timeseries
-        
+
         # run
         array = cutoff_window_sequences(
             X,
             timeseries,
             window_size=0,
         )
-        
+
         # assert
-        expected_array = np.array([np.array([[ 1, 21],
-                            [ 2, 22],
-                            [ 3, 23],
-                            [ 4, 24]]),
-                            np.array([[11, 31],
-                            [12, 32],
-                            [13, 33],
-                            [14, 34],
-                            [15, 35],
-                            [16, 36]])],dtype=object)
-        assert_allclose(array, expected_array)
-        
+        assert len(array) == 2
+        assert_allclose(
+            array[0],
+            np.array([
+                [1, 21],
+                [2, 22],
+                [3, 23],
+                [4, 24]
+            ])
+        )
+        assert_allclose(
+            array[1],
+            np.array([
+                [11, 31],
+                [12, 32],
+                [13, 33],
+                [14, 34],
+                [15, 35],
+                [16, 36]
+            ])
+        )
+
     def test_not_id(self):
         # setup
         X = self.X
         del X['id']
         timeseries = self.timeseries
         del timeseries['id']
-        
+
         # run
         array = cutoff_window_sequences(
             X,
             timeseries,
             window_size=3,
         )
-        
+
         # assert
         expected_array = np.array([[[12, 32],
-                            [13, 33],
-                            [14, 34]],
-                           [[14, 34],
-                            [15, 35],
-                            [16, 36]]])
+                                    [13, 33],
+                                    [14, 34]],
+                                   [[14, 34],
+                                    [15, 35],
+                                    [16, 36]]])
         assert_allclose(array, expected_array)
-        
+
     def test_not_values(self):
         # setup
         X = self.X
         timeseries = self.timeseries
         del timeseries['value1']
         del timeseries['value2']
-        
+
         # run
         array = cutoff_window_sequences(
             X,
             timeseries,
             window_size=3,
         )
-        
+
         # assert
-        expected_array = np.array([[[],[],[]],[[],[],[]]])
+        expected_array = np.array([[[], [], []], [[], [], []]])
         assert_allclose(array, expected_array)
-        

--- a/tests/custom/test_timeseries_preprocessing.py
+++ b/tests/custom/test_timeseries_preprocessing.py
@@ -260,6 +260,7 @@ class CutoffWindowSequencesTest(TestCase):
             'id': [1] * 10 + [2] * 10
         }).set_index('timestamp')
 
+    """Passing cutoff_time. The indicated column will be used as the cutoff time."""
     def test_cutoff_time_column(self):
         # setup
         timeseries = self.timeseries
@@ -274,14 +275,18 @@ class CutoffWindowSequencesTest(TestCase):
         )
 
         # assert
-        expected_array = np.array([[[2, 22],
-                                    [3, 23],
-                                    [4, 24]],
-                                   [[14, 34],
-                                    [15, 35],
-                                    [16, 36]]])
+        expected_array = np.array([
+            [[2, 22],
+             [3, 23],
+             [4, 24]],
+            [[14, 34],
+             [15, 35],
+             [16, 36]]
+        ])
+
         assert_allclose(array, expected_array)
 
+    """Passing time_index. The indicated column will be used as the timeseries index."""
     def test_time_index_column(self):
         # setup
         X = self.X
@@ -296,14 +301,18 @@ class CutoffWindowSequencesTest(TestCase):
         )
 
         # assert
-        expected_array = np.array([[[2, 22],
-                                    [3, 23],
-                                    [4, 24]],
-                                   [[14, 34],
-                                    [15, 35],
-                                    [16, 36]]])
+        expected_array = np.array([
+            [[2, 22],
+             [3, 23],
+             [4, 24]],
+            [[14, 34],
+             [15, 35],
+             [16, 36]]
+        ])
+
         assert_allclose(array, expected_array)
 
+    """window_size accepts integer."""
     def test_window_size_integer(self):
         # setup
         X = self.X
@@ -317,14 +326,18 @@ class CutoffWindowSequencesTest(TestCase):
         )
 
         # assert
-        expected_array = np.array([[[2, 22],
-                                    [3, 23],
-                                    [4, 24]],
-                                   [[14, 34],
-                                    [15, 35],
-                                    [16, 36]]])
+        expected_array = np.array([
+            [[2, 22],
+             [3, 23],
+             [4, 24]],
+            [[14, 34],
+             [15, 35],
+             [16, 36]]
+        ])
+
         assert_allclose(array, expected_array)
 
+    """window_size accepts string."""
     def test_window_size_string(self):
         # setup
         X = self.X
@@ -338,14 +351,18 @@ class CutoffWindowSequencesTest(TestCase):
         )
 
         # assert
-        expected_array = np.array([[[2, 22],
-                                    [3, 23],
-                                    [4, 24]],
-                                   [[14, 34],
-                                    [15, 35],
-                                    [16, 36]]])
+        expected_array = np.array([
+            [[2, 22],
+             [3, 23],
+             [4, 24]],
+            [[14, 34],
+             [15, 35],
+             [16, 36]]
+        ])
+
         assert_allclose(array, expected_array)
 
+    """window_size accepts Timedelta object."""
     def test_window_size_timedelta(self):
         # setup
         X = self.X
@@ -359,15 +376,19 @@ class CutoffWindowSequencesTest(TestCase):
         )
 
         # assert
-        expected_array = np.array([[[2, 22],
-                                    [3, 23],
-                                    [4, 24]],
-                                   [[14, 34],
-                                    [15, 35],
-                                    [16, 36]]])
+        expected_array = np.array([
+            [[2, 22],
+             [3, 23],
+             [4, 24]],
+            [[14, 34],
+             [15, 35],
+             [16, 36]]
+        ])
+
         assert_allclose(array, expected_array)
 
-    def test_large_window_size(self):
+    """If there is not enough data for the given window_size, shape changes."""
+    def test_not_enough_data(self):
         # setup
         X = self.X
         timeseries = self.timeseries
@@ -381,17 +402,14 @@ class CutoffWindowSequencesTest(TestCase):
 
         # assert
         assert len(array) == 2
-        assert_allclose(
-            array[0],
+
+        expected_array = np.array([
             np.array([
                 [1, 21],
                 [2, 22],
                 [3, 23],
                 [4, 24]
-            ])
-        )
-        assert_allclose(
-            array[1],
+            ]),
             np.array([
                 [12, 32],
                 [13, 33],
@@ -399,44 +417,20 @@ class CutoffWindowSequencesTest(TestCase):
                 [15, 35],
                 [16, 36]
             ])
-        )
+        ])
 
-    def test_window_size_zero(self):
-        # setup
-        X = self.X
-        timeseries = self.timeseries
-
-        # run
-        array = cutoff_window_sequences(
-            X,
-            timeseries,
-            window_size=0,
-        )
-
-        # assert
-        assert len(array) == 2
         assert_allclose(
             array[0],
-            np.array([
-                [1, 21],
-                [2, 22],
-                [3, 23],
-                [4, 24]
-            ])
-        )
-        assert_allclose(
-            array[1],
-            np.array([
-                [11, 31],
-                [12, 32],
-                [13, 33],
-                [14, 34],
-                [15, 35],
-                [16, 36]
-            ])
+            expected_array[0]
         )
 
-    def test_not_id(self):
+        assert_allclose(
+            array[1],
+            expected_array[1]
+        )
+
+    """Test X without any other column than cutoff_time."""
+    def test_cutoff_time_only(self):
         # setup
         X = self.X
         del X['id']
@@ -451,28 +445,13 @@ class CutoffWindowSequencesTest(TestCase):
         )
 
         # assert
-        expected_array = np.array([[[12, 32],
-                                    [13, 33],
-                                    [14, 34]],
-                                   [[14, 34],
-                                    [15, 35],
-                                    [16, 36]]])
-        assert_allclose(array, expected_array)
+        expected_array = np.array([
+            [[12, 32],
+             [13, 33],
+             [14, 34]],
+            [[14, 34],
+             [15, 35],
+             [16, 36]]
+        ])
 
-    def test_not_values(self):
-        # setup
-        X = self.X
-        timeseries = self.timeseries
-        del timeseries['value1']
-        del timeseries['value2']
-
-        # run
-        array = cutoff_window_sequences(
-            X,
-            timeseries,
-            window_size=3,
-        )
-
-        # assert
-        expected_array = np.array([[[], [], []], [[], [], []]])
         assert_allclose(array, expected_array)

--- a/tests/custom/test_timeseries_preprocessing.py
+++ b/tests/custom/test_timeseries_preprocessing.py
@@ -246,7 +246,7 @@ class CutoffWindowSequencesTest(TestCase):
 
     def setUp(self):
         self.X = pd.DataFrame({
-            'id': [1, 2],
+            'id1': [1, 2],
             'cutoff': pd.to_datetime(['2020-01-05', '2020-01-07'])
         }).set_index('cutoff')
         self.timeseries = pd.DataFrame({
@@ -257,11 +257,11 @@ class CutoffWindowSequencesTest(TestCase):
             )) * 2,
             'value1': np.arange(1, 21),
             'value2': np.arange(21, 41),
-            'id': [1] * 10 + [2] * 10
+            'id1': [1] * 10 + [2] * 10
         }).set_index('timestamp')
 
-    """Passing cutoff_time. The indicated column will be used as the cutoff time."""
     def test_cutoff_time_column(self):
+        """Passing cutoff_time. The indicated column will be used as the cutoff time."""
         # setup
         timeseries = self.timeseries
         X = self.X.reset_index()
@@ -286,8 +286,8 @@ class CutoffWindowSequencesTest(TestCase):
 
         assert_allclose(array, expected_array)
 
-    """Passing time_index. The indicated column will be used as the timeseries index."""
     def test_time_index_column(self):
+        """Passing time_index. The indicated column will be used as the timeseries index."""
         # setup
         X = self.X
         timeseries = self.timeseries.reset_index()
@@ -312,8 +312,8 @@ class CutoffWindowSequencesTest(TestCase):
 
         assert_allclose(array, expected_array)
 
-    """window_size accepts integer."""
     def test_window_size_integer(self):
+        """window_size accepts integer."""
         # setup
         X = self.X
         timeseries = self.timeseries
@@ -337,8 +337,8 @@ class CutoffWindowSequencesTest(TestCase):
 
         assert_allclose(array, expected_array)
 
-    """window_size accepts string."""
     def test_window_size_string(self):
+        """window_size accepts string."""
         # setup
         X = self.X
         timeseries = self.timeseries
@@ -362,8 +362,8 @@ class CutoffWindowSequencesTest(TestCase):
 
         assert_allclose(array, expected_array)
 
-    """window_size accepts Timedelta object."""
     def test_window_size_timedelta(self):
+        """window_size accepts Timedelta object."""
         # setup
         X = self.X
         timeseries = self.timeseries
@@ -387,8 +387,8 @@ class CutoffWindowSequencesTest(TestCase):
 
         assert_allclose(array, expected_array)
 
-    """If there is not enough data for the given window_size, shape changes."""
     def test_not_enough_data(self):
+        """If there is not enough data for the given window_size, shape changes."""
         # setup
         X = self.X
         timeseries = self.timeseries
@@ -429,13 +429,13 @@ class CutoffWindowSequencesTest(TestCase):
             expected_array[1]
         )
 
-    """Test X without any other column than cutoff_time."""
     def test_cutoff_time_only(self):
+        """Test X without any other column than cutoff_time."""
         # setup
         X = self.X
-        del X['id']
+        del X['id1']
         timeseries = self.timeseries
-        del timeseries['id']
+        del timeseries['id1']
 
         # run
         array = cutoff_window_sequences(
@@ -451,6 +451,31 @@ class CutoffWindowSequencesTest(TestCase):
              [14, 34]],
             [[14, 34],
              [15, 35],
+             [16, 36]]
+        ])
+
+        assert_allclose(array, expected_array)
+
+    def test_multiple_filter(self):
+        """Test X with two identifier columns."""
+        # setup
+        X = self.X
+        X['id2'] = [3, 4]
+        timeseries = self.timeseries
+        timeseries['id2'] = [3, 4] * 10
+
+        # run
+        array = cutoff_window_sequences(
+            X,
+            timeseries,
+            window_size=2,
+        )
+
+        # assert
+        expected_array = np.array([
+            [[1, 21],
+             [3, 23]],
+            [[14, 34],
              [16, 36]]
         ])
 

--- a/tests/custom/test_timeseries_preprocessing.py
+++ b/tests/custom/test_timeseries_preprocessing.py
@@ -6,7 +6,8 @@ import pytest
 from numpy.testing import assert_allclose
 
 from mlprimitives.custom.timeseries_preprocessing import (
-    intervals_to_mask, rolling_window_sequences, time_segments_aggregate, time_segments_average, cutoff_window_sequences)
+    intervals_to_mask, rolling_window_sequences, time_segments_aggregate,
+    time_segments_average, cutoff_window_sequences)
 
 
 class IntervalsToMaskTest(TestCase):
@@ -241,103 +242,221 @@ class TimeSegmentsAggregateTest(TestCase):
         self._run(X, interval, expected_values, expected_index, time_column=0,
                   method=['mean', 'median'])
         
+        
 class CutoffWindowSequencesTest(TestCase):
     
     def setUp(self):
         self.X = pd.DataFrame({
             'id': [1, 2],
             'cutoff': pd.to_datetime(['2020-01-05', '2020-01-07'])
-        })
+        }).set_index('cutoff')
         self.timeseries = pd.DataFrame({
             'timestamp': list(pd.date_range(
                 start='2020-01-01',
                 end='2020-01-10',
                 freq='1d'
             )) * 2,
-            'value': np.arange(1, 21),
+            'value1': np.arange(1, 21),
+            'value2': np.arange(21, 41),
             'id': [1] * 10 + [2] * 10
-        })
+        }).set_index('timestamp')
         
-    def test_cutoff_time_not_index(self):
-        #setup
-        timeseries = self.timeseries.set_index('timestamp')
+    def test_cutoff_time_column(self):
+        # setup
+        timeseries = self.timeseries
+        X = self.X.reset_index()
         
-        #run
+        # run
         array = cutoff_window_sequences(
-            self.X,
+            X,
             timeseries,
             window_size=3,
             cutoff_time='cutoff',
         )
         
-        #assert
-        expected_array = np.array([[[2],[3],[4]], [[14],[15],[16]]])
+        # assert
+        expected_array = np.array([[[ 2, 22],
+                            [ 3, 23],
+                            [ 4, 24]],
+                            [[14, 34],
+                            [15, 35],
+                            [16, 36]]])
         assert_allclose(array,expected_array)
     
-    def test_time_index_not_index(self):
-        #setup
-        X = self.X.set_index('cutoff')
+    def test_time_index_column(self):
+        # setup
+        X = self.X
+        timeseries = self.timeseries.reset_index()
         
-        #run
+        # run
         array = cutoff_window_sequences(
             X,
-            self.timeseries,
+            timeseries,
             window_size=3,
             time_index='timestamp',
         )
         
-        #assert
-        expected_array = np.array([[[2],[3],[4]], [[14],[15],[16]]])
+        # assert
+        expected_array = np.array([[[ 2, 22],
+                            [ 3, 23],
+                            [ 4, 24]],
+                            [[14, 34],
+                            [15, 35],
+                            [16, 36]]])
         assert_allclose(array,expected_array)
         
     def test_window_size_integer(self):
-        #setup
-        X = self.X.set_index('cutoff')
-        timeseries = self.timeseries.set_index('timestamp')
+        # setup
+        X = self.X
+        timeseries = self.timeseries
         
-        #run
+        # run
         array = cutoff_window_sequences(
             X,
             timeseries,
             window_size=3,
         )
         
-        #assert
-        expected_array = np.array([[[2],[3],[4]], [[14],[15],[16]]])
+        # assert
+        expected_array = np.array([[[ 2, 22],
+                            [ 3, 23],
+                            [ 4, 24]],
+                            [[14, 34],
+                            [15, 35],
+                            [16, 36]]])
         assert_allclose(array,expected_array)
     
-    #At the moment, it fails
-    #@pytest.mark.xfail
     def test_window_size_string(self):
-        #setup
-        X = self.X.set_index('cutoff')
-        timeseries = self.timeseries.set_index('timestamp')
+        # setup
+        X = self.X
+        timeseries = self.timeseries
         
-        #run
+        # run
         array = cutoff_window_sequences(
             X,
             timeseries,
             window_size='3d',
         )
         
-        #assert
-        expected_array = np.array([[[2],[3],[4]], [[14],[15],[16]]])
+        # assert
+        expected_array = np.array([[[ 2, 22],
+                            [ 3, 23],
+                            [ 4, 24]],
+                            [[14, 34],
+                            [15, 35],
+                            [16, 36]]])
         assert_allclose(array,expected_array)
     
-    #At the moment, it fails
-    #@pytest.mark.xfail
     def test_window_size_timedelta(self):
-        #setup
-        X = self.X.set_index('cutoff')
-        timeseries = self.timeseries.set_index('timestamp')
+        # setup
+        X = self.X
+        timeseries = self.timeseries
         
-        #run
+        # run
         array = cutoff_window_sequences(
-                X,
-                timeseries,
-                window_size=pd.Timedelta(days=3),
-            )
+            X,
+            timeseries,
+            window_size=pd.Timedelta(days=3),
+        )
 
-        #assert
-        expected_array = np.array([[[2],[3],[4]], [[14],[15],[16]]])
+        # assert
+        expected_array = np.array([[[ 2, 22],
+                            [ 3, 23],
+                            [ 4, 24]],
+                            [[14, 34],
+                            [15, 35],
+                            [16, 36]]])
         assert_allclose(array,expected_array)
+        
+    @pytest.mark.xfail       
+    def test_large_window_size(self):
+        # setup
+        X = self.X
+        timeseries = self.timeseries
+        
+        # run
+        array = cutoff_window_sequences(
+            X,
+            timeseries,
+            window_size=5,
+        )
+        
+        # assert
+        expected_array = np.array([np.array([[ 1, 21],
+                            [ 2, 22],
+                            [ 3, 23],
+                            [ 4, 24]]),
+                            np.array([[12, 32],
+                            [13, 33],
+                            [14, 34],
+                            [15, 35],
+                            [16, 36]])])
+        assert_allclose(array, expected_array)
+        
+    @pytest.mark.xfail       
+    def test_window_size_zero(self):
+        # setup
+        X = self.X
+        timeseries = self.timeseries
+        
+        # run
+        array = cutoff_window_sequences(
+            X,
+            timeseries,
+            window_size=0,
+        )
+        
+        # assert
+        expected_array = np.array([np.array([[ 1, 21],
+                            [ 2, 22],
+                            [ 3, 23],
+                            [ 4, 24]]),
+                            np.array([[11, 31],
+                            [12, 32],
+                            [13, 33],
+                            [14, 34],
+                            [15, 35],
+                            [16, 36]])],dtype=object)
+        assert_allclose(array, expected_array)
+        
+    def test_not_id(self):
+        # setup
+        X = self.X
+        del X['id']
+        timeseries = self.timeseries
+        del timeseries['id']
+        
+        # run
+        array = cutoff_window_sequences(
+            X,
+            timeseries,
+            window_size=3,
+        )
+        
+        # assert
+        expected_array = np.array([[[12, 32],
+                            [13, 33],
+                            [14, 34]],
+                           [[14, 34],
+                            [15, 35],
+                            [16, 36]]])
+        assert_allclose(array, expected_array)
+        
+    def test_not_values(self):
+        # setup
+        X = self.X
+        timeseries = self.timeseries
+        del timeseries['value1']
+        del timeseries['value2']
+        
+        # run
+        array = cutoff_window_sequences(
+            X,
+            timeseries,
+            window_size=3,
+        )
+        
+        # assert
+        expected_array = np.array([[[],[],[]],[[],[],[]]])
+        assert_allclose(array, expected_array)
+        


### PR DESCRIPTION
Resolves #239

Two files modified in order to guarantee that the `window_size` parameter of the primitive `mlprimitives.custom.timeseries_preprocessing` accepts `pd.Timedelta` objects and a `str` as well.